### PR TITLE
Add missing txindex

### DIFF
--- a/build/templates/backend/config/syscoin.conf
+++ b/build/templates/backend/config/syscoin.conf
@@ -3,7 +3,9 @@ daemon=1
 server=1
 {{if .Backend.Mainnet}}{{else}}testnet=1{{end}}
 nolisten=1
+txindex=1
 disablewallet=1
+
 rpcuser={{.IPC.RPCUser}}
 rpcpassword={{.IPC.RPCPass}}
 zmqpubhashtx={{template "IPC.MessageQueueBindingTemplate" .}}


### PR DESCRIPTION
W/o txindex on a fresh synced server, blockbook gives a transaction not found error for old transaction.
This seems to be related to different code path in blockbook for bulk load and single block load, since more recent transactions are still found.
With txindex the same old transactions are found.
(Default setting for bitcoin and others too).