### PR TITLE
Change searchbar text color to black

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -37,7 +37,7 @@ h3 {
 
 .navbar-form .form-control {
     background-color: #f5f5f5;;
-    color: #fff;
+    color: #0f0f0f;
     border-radius: 70px;
     -webkit-border-radius: 70px;
     -moz-border-radius: 70px;

--- a/static/templates/base.html
+++ b/static/templates/base.html
@@ -41,7 +41,7 @@
                     </ul>
                     <span class="navbar-form ml-md-auto">
                         <form id="search" action="/search" method="get">
-                            <input name="q" type="text" class="form-control" placeholder="Search for block, transaction, address or xpub" focus="true">
+                            <input name="q" type="text" class="form-control" placeholder="Search for block, transaction, address or xpub" focus="true" style="color: black;">
                         </form>
                     </span>
                     {{- end -}}

--- a/static/templates/base.html
+++ b/static/templates/base.html
@@ -41,7 +41,7 @@
                     </ul>
                     <span class="navbar-form ml-md-auto">
                         <form id="search" action="/search" method="get">
-                            <input name="q" type="text" class="form-control" placeholder="Search for block, transaction, address or xpub" focus="true" style="color: black;">
+                            <input name="q" type="text" class="form-control" placeholder="Search for block, transaction, address or xpub" focus="true">
                         </form>
                     </span>
                     {{- end -}}


### PR DESCRIPTION
PR to fix a reported issue that the search field text and background were with the same color (white), which was causing the user not to see what they were writing or pasting. The text color was changed to black.